### PR TITLE
Fix walletpath option in wallet command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -168,7 +168,7 @@ const mspidBuilder = (yargs: any) => {
 const walletBuilder = (yargs: any) => {
     return yargs
         .options({
-            walletpath: { alias: 'w', describe: 'Path to application wallet', demandOption: true },
+            wallet: { alias: 'w', describe: 'Path to application wallet', demandOption: true },
             compat: {
                 alias: 'c',
                 describe: 'Set to use the 1.4 wallet format',


### PR DESCRIPTION
Example error:

```
$ weft wallet ls --walletpath ./_cfg/_wallets/DigiBank
weft wallet ls

Lists Application Wallet identities

Opciones:
      --help          Muestra ayuda  [booleano]
  -v, --version       Muestra número de versión  [booleano]
  -w, --walletpath    Path to application wallet  [requerido]
  -c, --compat        Set to use the 1.4 wallet format  [booleano] [defecto: false]
  -r, --createwallet  Create the wallet if not present  [booleano] [defecto: false]
  -f, --force         If the identity is already present, force overwrite it  [booleano] [defecto: false]

TypeError: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:399:5)
    at validateString (node:internal/validators:163:11)
    at Object.resolve (node:path:1102:7)
    at resolveWalletPath (/opt/homebrew/lib/node_modules/@hyperledger-labs/weft/src/userutils.ts:12:19)
    at /opt/homebrew/lib/node_modules/@hyperledger-labs/weft/src/cli.ts:267:53
    at Generator.next (<anonymous>)
    at /opt/homebrew/lib/node_modules/@hyperledger-labs/weft/lib/cli.js:32:71
    at new Promise (<anonymous>)
    at __awaiter (/opt/homebrew/lib/node_modules/@hyperledger-labs/weft/lib/cli.js:28:12)
    at Object.handler (/opt/homebrew/lib/node_modules/@hyperledger-labs/weft/src/cli.ts:265:33) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

After the fix:

```
weft wallet ls --wallet ./_cfg/_wallets/DigiBank
Listing application wallet identities /Users/japi/tmp/_cfg/_wallets/DigiBank
Complete
> digibankadmin
> digibankcaadmin

```
The problem occurs because it uses args['wallet'] instead of args['walletpath']:

```
        .command(
            'ls',
            'Lists Application Wallet identities',
            (yargs: any) => {
                return yargs;
            },
            async (args: any) => {
                // resolve the supplied gateway and wallet paths
                const walletPath = resolveWalletPath(args['wallet'] as string);
                log({ msg: 'Listing application wallet identities', val: walletPath });

                const idtools = new Identities(walletPath);
                idtools.list();
            },
        );

```